### PR TITLE
Updated segment path, inference documentation, added support for reversing segment tif stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+timesformer_*.ckpt

--- a/inference_timesformer.py
+++ b/inference_timesformer.py
@@ -23,6 +23,8 @@ import PIL.Image
 PIL.Image.MAX_IMAGE_PIXELS = 933120000
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 from tap import Tap
+import glob
+
 class InferenceArgumentParser(Tap):
     segment_id: list[str] =['20230925002745']
     segment_path:str='./eval_scrolls'
@@ -108,19 +110,26 @@ def read_image_mask(fragment_id,start_idx=18,end_idx=38,rotation=0):
     end = mid + CFG.in_chans // 2
     idxs = range(start_idx, end_idx)
     for i in idxs:
-        image = cv2.imread(f"./train_scrolls/{fragment_id}/layers/{i:02}.tif", 0)
+        image = cv2.imread(f"{args.segment_path}/{fragment_id}/layers/{i:02}.tif", 0)
         pad0 = (256 - image.shape[0] % 256)
         pad1 = (256 - image.shape[1] % 256)
         image = np.pad(image, [(0, pad0), (0, pad1)], constant_values=0)
         image=np.clip(image,0,200)
         images.append(image)
     images = np.stack(images, axis=2)
-    if fragment_id in ['20230701020044','verso','20230901184804','20230901234823','20230531193658','20231007101615','20231005123333','20231011144857','20230522215721', '20230919113918', '20230625171244','20231022170900','20231012173610','20231016151000']:
+    if args.reverse != 0 or fragment_id in ['20230701020044','verso','20230901184804','20230901234823','20230531193658','20231007101615','20231005123333','20231011144857','20230522215721', '20230919113918', '20230625171244','20231022170900','20231012173610','20231016151000']:
+        print("Reverse Segment")
         images=images[:,:,::-1]
 
     fragment_mask=None
-    if os.path.exists(f'./train_scrolls/{fragment_id}/{fragment_id}_mask.png'):
-        fragment_mask=cv2.imread(CFG.comp_dataset_path + f"train_scrolls/{fragment_id}/{fragment_id}_mask.png", 0)
+    wildcard_path_mask = f'{args.segment_path}/{fragment_id}/*_mask.png'
+    if os.path.exists(f'{args.segment_path}/{fragment_id}/{fragment_id}_mask.png'):
+        fragment_mask=cv2.imread(CFG.comp_dataset_path + f"{args.segment_path}/{fragment_id}/{fragment_id}_mask.png", 0)
+        fragment_mask = np.pad(fragment_mask, [(0, pad0), (0, pad1)], constant_values=0)
+    elif len(glob.glob(wildcard_path_mask)) > 0:
+        # any *mask.png exists
+        mask_path = glob.glob(wildcard_path_mask)[0]
+        fragment_mask = cv2.imread(mask_path, 0)
         fragment_mask = np.pad(fragment_mask, [(0, pad0), (0, pad1)], constant_values=0)
 
     return images,fragment_mask
@@ -303,7 +312,7 @@ if __name__ == "__main__":
         name=f"ALL_scrolls_tta", 
         )
     for fragment_id in args.segment_id:
-        if os.path.exists(f"train_scrolls/{fragment_id}/layers/00.tif"):
+        if os.path.exists(f"{args.segment_path}/{fragment_id}/layers/00.tif"):
             preds=[]
             for r in [0]:
                 for i in [17]:

--- a/readme.md
+++ b/readme.md
@@ -38,3 +38,5 @@ To run inference of timesformer:
 ```bash
 python inference_timesformer.py --segment_id 20231210121321 20231221180251 --segment_path $(pwd)/train_scrolls --model_path timesformer_wild15_20230702185753_0_fr_i3depoch=12.ckpt
 ```
+
+The optional parameter ```--out_path``` can be used to specify the output path of the predictions.

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,5 @@ You can find the weights of the canonical timesformer uploaded [here](https://dr
 To run inference of timesformer:
 
 ```bash
-python inference_timesformer.py --segment_id 20231210121321 20231221180251 --segment_path train_scrolls --model_path timesformer_wild15_20230702185753_0_fr_i3depoch=12.ckpt
+python inference_timesformer.py --segment_id 20231210121321 20231221180251 --segment_path $(pwd)/train_scrolls --model_path timesformer_wild15_20230702185753_0_fr_i3depoch=12.ckpt
 ```
-


### PR DESCRIPTION
Added capability to run inference with segments from any path
- implemented --reverse argument
- updated inference documentation
- loading of mask can now use any *_mask.png if the default mask was not found